### PR TITLE
Allow setting autocomplete as route name

### DIFF
--- a/lib/ransack_ui/adapters/active_record/base.rb
+++ b/lib/ransack_ui/adapters/active_record/base.rb
@@ -16,8 +16,8 @@ module RansackUI
           self._ransackable_associations = associations
         end
 
-        def ransack_autocompletes_through(controller)
-          self._ransack_autocompletes_through = controller
+        def ransack_autocompletes_through(*source_args)
+          self._ransack_autocompletes_through = source_args
         end
 
         # Return array of attributes with [name, type]

--- a/lib/ransack_ui/ransack_overrides/helpers/form_builder.rb
+++ b/lib/ransack_ui/ransack_overrides/helpers/form_builder.rb
@@ -163,15 +163,24 @@ module Ransack
             }.to_json
           end
 
-          if foreign_klass && foreign_klass.constantize._ransack_autocompletes_through
+          if foreign_klass && (autocomplete_source = foreign_klass.constantize._ransack_autocompletes_through rescue false)
+            url = case autocomplete_source.first
+                  when Class
+                    controller_path = autocomplete_source.first.controller_path
+                    if ajax_options[:url]
+                      ajax_options[:url].sub(':controller', controller_path)
+                    else
+                      "/#{controller_path}.json"
+                    end
+                  else
+                    route_name = autocomplete_source.first.to_s.gsub(/_(url|path)$/, '')
+                    controller_path = Rails.application.routes.named_routes[route_name].defaults[:controller]
+                    Rails.application.routes_url_helpers.send(*autocomplete_source)
+                  end
+
             # If field is a foreign key, set up 'data-ajax-*' attributes for auto-complete
-            controller = foreign_klass.constantize._ransack_autocompletes_through.controller_path
-            html_options[:'data-ajax-entity'] = I18n.translate(controller, :default => controller)
-            if ajax_options[:url]
-              html_options[:'data-ajax-url'] = ajax_options[:url].sub(':controller', controller)
-            else
-              html_options[:'data-ajax-url'] = "/#{controller}.json"
-            end
+            html_options[:'data-ajax-url'] = url
+            html_options[:'data-ajax-entity'] = I18n.translate(controller_path, :default => controller_path)
             html_options[:'data-ajax-type'] = ajax_options[:type] || 'GET'
             html_options[:'data-ajax-key']  = ajax_options[:key]  || 'query'
           end


### PR DESCRIPTION
Instead of relying on hacking `controller_path` to get around routes that don't match the controller name, we sometimes need to set the route by name.

```
ransack_autocompletes_through :some_resource_autocomplete_path, :format => :json
```

Passing the controller class for replacing into the `ajax_options[:url]` pattern is still supported as before.
